### PR TITLE
fix(ci): use pre-release version for PR pack step + nuget updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,9 +95,15 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack
+      - name: Pack (stable — push to master)
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: |
           dotnet pack Tharga.Crawler/Tharga.Crawler.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+
+      - name: Pack (pre-release — pull request)
+        if: github.event_name == 'pull_request'
+        run: |
+          dotnet pack Tharga.Crawler/Tharga.Crawler.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/Sample/Tharga.Crawler.SampleConsole/CustomDownloader.cs
+++ b/Sample/Tharga.Crawler.SampleConsole/CustomDownloader.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Tharga.Crawler.Downloader;
+﻿using Tharga.Crawler.Downloader;
 using Tharga.Crawler.Entity;
 
 namespace Tharga.Crawler.SampleConsole;
@@ -10,6 +9,5 @@ public class CustomDownloader : HttpClientDownloader
     {
         //return new CrawlContent();
         throw new NotImplementedException();
-        Debugger.Break();
     }
 }

--- a/Sample/Tharga.Crawler.SampleConsole/CustomPageProcessor.cs
+++ b/Sample/Tharga.Crawler.SampleConsole/CustomPageProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Tharga.Crawler.Entity;
+﻿using Tharga.Crawler.Entity;
 
 namespace Tharga.Crawler.SampleConsole;
 
@@ -9,6 +8,5 @@ public class CustomPageProcessor : PageProcessor.BasicPageProcessor
     {
         //yield return new ToCrawl();
         throw new NotImplementedException();
-        Debugger.Break();
     }
 }

--- a/Sample/Tharga.Crawler.SampleConsole/CustomScheduler.cs
+++ b/Sample/Tharga.Crawler.SampleConsole/CustomScheduler.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Tharga.Crawler.Entity;
 using Tharga.Crawler.Scheduler;
 
@@ -15,20 +14,17 @@ public class CustomScheduler : MemoryScheduler
     public override Task EnqueueAsync(ToCrawl toCrawl, SchedulerOptions options)
     {
         throw new NotImplementedException();
-        Debugger.Break();
     }
 
     public override IAsyncEnumerable<Crawled> GetAllCrawled()
     {
         //yield return new Crawled();
         throw new NotImplementedException();
-        Debugger.Break();
     }
 
     public override Task<ToCrawlScope> GetQueuedItemScope(CancellationToken cancellationToken)
     {
         //return new ToCrawlScope();
         throw new NotImplementedException();
-        Debugger.Break();
     }
 }

--- a/Sample/Tharga.Crawler.SampleConsole/Program.cs
+++ b/Sample/Tharga.Crawler.SampleConsole/Program.cs
@@ -8,7 +8,7 @@ using Tharga.Crawler.SampleConsole.Commands;
 
 var services = new ServiceCollection();
 services.AddTransient<CrawlCommand>();
-services.RegisterCrawler();
+services.AddCrawler();
 services.AddLogging(x =>
 {
     x.AddConsole();

--- a/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
+++ b/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
@@ -7,7 +7,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
 		<PackageReference Include="Tharga.Console" Version="3.7.2" />
 	</ItemGroup>
 

--- a/Tharga.Crawler.Tests/MemorySchedulerTests.cs
+++ b/Tharga.Crawler.Tests/MemorySchedulerTests.cs
@@ -6,7 +6,6 @@ using Moq;
 using Tharga.Crawler.Entity;
 using Tharga.Crawler.Scheduler;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Tharga.Crawler.Tests;
 

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
+		<NoWarn>$(NoWarn);xUnit1051</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -9,23 +9,23 @@
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.9.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.6" />
-		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.7" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="8.0.1">
+		<PackageReference Include="coverlet.msbuild" Version="10.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="8.0.1">
+		<PackageReference Include="coverlet.collector" Version="10.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Crawler/Tharga.Crawler.csproj
+++ b/Tharga.Crawler/Tharga.Crawler.csproj
@@ -30,8 +30,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.6" />
-		<PackageReference Include="System.Linq.Async" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+		<PackageReference Include="System.Linq.Async" Version="7.0.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<InternalsVisibleTo Include="Tharga.Crawler.Tests" />


### PR DESCRIPTION
## Summary
- **CI fix**: Pack step split into two conditional steps — stable on master push, pre-release on PR. Prevents PR runs from publishing the stable version under a pre-release GitHub Release.
- **NuGet package updates**: Microsoft.Extensions.Hosting 10.0.7, System.Linq.Async 7.0.1, Microsoft.NET.Test.Sdk 18.5.1, Microsoft.AspNetCore.Mvc.Testing 10.0.7, Tharga.Test.Toolkit 1.14.7, coverlet.msbuild/coverlet.collector 10.0.0, xunit.v3 3.2.2.

Note: Tharga.Console 3.7.3 attempted but skipped — package declares dependency on Tharga.Console.Standard >= 3.7.3 but only 3.7.2 is published. Tracked in Requests.md.

## Test plan
- [x] All tests pass locally
- [ ] Verify CI runs the new pre-release pack step correctly on this PR