### PR TITLE
chore: update nuget packages

### DIFF
--- a/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
+++ b/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="3.7.2" />
+		<PackageReference Include="Tharga.Console" Version="4.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -8,12 +8,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="FluentAssertions" Version="8.9.0" />
+		<PackageReference Include="FluentAssertions" Version="8.10.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.7" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.9" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.Crawler/Tharga.Crawler.csproj
+++ b/Tharga.Crawler/Tharga.Crawler.csproj
@@ -30,7 +30,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
 		<PackageReference Include="System.Linq.Async" Version="7.0.1" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- **Tharga.Console** 3.7.2 → 4.1.1 (resolves the earlier 3.7.3 broken-dependency issue by moving to the 4.x line)
- **Microsoft.Extensions.Hosting** 10.0.7 → 10.0.8
- **FluentAssertions** 8.9.0 → 8.10.0
- **Microsoft.AspNetCore.Mvc.Testing** 10.0.7 → 10.0.8
- **Tharga.Test.Toolkit** 1.14.7 → 1.14.9

## Test plan
- [x] Build succeeds with 0 warnings
- [x] All 44 tests pass locally