### PR TITLE
chore!: target net10.0 only, consume tier 1, declare licence

### DIFF
--- a/.claude/mission.md
+++ b/.claude/mission.md
@@ -3,6 +3,6 @@
 ## External References
 - **Shared instructions**: `$DOC_ROOT/Tharga/shared-instructions.md`
 - **Plan directory**: `$DOC_ROOT/Tharga/plans/Toolkit/Crawler`
-- **Backlog**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Toolkit\Crawler.md`
+- **Backlog**: `$DOC_ROOT/Tharga/Toolkit/Crawler.md`
 - **Incoming requests**: `c:\Users\danie\SynologyDrive\Documents\Notes\Tharga\Requests.md` — check for pending requests for this project on startup
 - **Eplicta requests**: `$DEV_ROOT/Eplicta/plan/requests.md` — check for requests from Eplicta on startup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,41 +28,17 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
-      - name: Restore
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build -c Release --no-restore 2>&1 | tee build.log
-
-      - name: Check warnings
-        run: |
-          WARNING_COUNT=$(grep -c " warning " build.log || true)
-          echo "Build warnings: $WARNING_COUNT"
-          if [ "$WARNING_COUNT" -gt 15 ]; then
-            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
-            exit 1
-          fi
-
-      - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          directory: ./coverage
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
-
+      # Version is computed BEFORE the build so it can be passed as -p:Version.
+      # Passing it only to `dotnet pack` sets PackageVersion alone, leaving
+      # AssemblyVersion and FileVersion at their default 1.0.0.0 inside the
+      # shipped assembly.
       - name: Compute version
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -97,15 +73,50 @@ jobs:
           echo "version=$PRE_VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed pre-release version: $PRE_VERSION"
 
-      - name: Pack (stable — push to master)
-        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      # Pull requests build the pre-release version, pushes to master the
+      # stable one. One value drives build and pack so the assembly and the
+      # package can never disagree.
+      - name: Resolve build version
+        id: buildversion
+        shell: bash
         run: |
-          dotnet pack Tharga.Crawler/Tharga.Crawler.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.version.outputs.version }}
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            VERSION="${{ steps.preversion.outputs.version }}"
+          else
+            VERSION="${{ steps.version.outputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building as: $VERSION"
 
-      - name: Pack (pre-release — pull request)
-        if: github.event_name == 'pull_request'
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build -c Release --no-restore -p:Version=${{ steps.buildversion.outputs.version }} 2>&1 | tee build.log
+
+      - name: Check warnings
         run: |
-          dotnet pack Tharga.Crawler/Tharga.Crawler.csproj -c Release --no-build -o ./artifacts -p:PackageVersion=${{ steps.preversion.outputs.version }}
+          WARNING_COUNT=$(grep -c " warning " build.log || true)
+          echo "Build warnings: $WARNING_COUNT"
+          if [ "$WARNING_COUNT" -gt 15 ]; then
+            echo "::error::Build has $WARNING_COUNT warnings (threshold: 15)"
+            exit 1
+          fi
+
+      - name: Test with coverage
+        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pack
+        shell: bash
+        run: |
+          dotnet pack Tharga.Crawler/Tharga.Crawler.csproj -c Release --no-build -o ./artifacts -p:Version=${{ steps.buildversion.outputs.version }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -127,10 +138,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Build for CodeQL
         run: dotnet build -c Release
@@ -164,7 +172,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -238,7 +246,7 @@ jobs:
         id: version
         run: |
           LATEST_TAG=$(git tag -l "${MAJOR_MINOR}.*" --sort=-v:refname \
-            | grep -E "^${MAJOR_MINOR}\.[0-9]+$" \
+            | { grep -E "^${MAJOR_MINOR}\.[0-9]+$" || true; } \
             | head -1)
 
           if [ -z "$LATEST_TAG" ]; then
@@ -289,10 +297,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            8.0.x
-            9.0.x
-            10.0.x
+          dotnet-version: 10.0.x
 
       - name: Install DocFX
         run: dotnet tool install -g docfx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,9 +188,17 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            # This previously ended in `|| true`, which is how symbol pushes
+            # failed silently for months.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Release
@@ -271,9 +279,17 @@ jobs:
 
       - name: Push to NuGet
         run: |
+          # Only *.nupkg is globbed. Each matching package's sibling .snupkg is
+          # uploaded automatically by dotnet nuget push, so symbols must NOT be
+          # pushed explicitly or nuget.org sees a duplicate.
+          ls -l ./artifacts/
           for pkg in ./artifacts/*.nupkg; do
             echo "Pushing $pkg..."
-            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate || true
+            # --skip-duplicate already makes a re-run of an existing version a
+            # success, so a failure here is a real failure and must fail the job.
+            # This previously ended in `|| true`, which is how symbol pushes
+            # failed silently for months.
+            dotnet nuget push "$pkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
           done
 
       - name: Create GitHub Pre-release

--- a/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
+++ b/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="4.1.2" />
+		<PackageReference Include="Tharga.Console" Version="4.2.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.10" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.12" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.Crawler.sln
+++ b/Tharga.Crawler.sln
@@ -9,6 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tharga.Crawler.Tests", "Tha
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A71FB6BE-1C62-4AB5-93AA-3E488721392A}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.gitignore = .gitignore
 		azure-pipelines.yml = azure-pipelines.yml
 		buildnumber.yml = buildnumber.yml

--- a/Tharga.Crawler.sln
+++ b/Tharga.Crawler.sln
@@ -11,8 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\build.yml = .github\workflows\build.yml
 		.gitignore = .gitignore
-		azure-pipelines.yml = azure-pipelines.yml
-		buildnumber.yml = buildnumber.yml
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/Tharga.Crawler/Tharga.Crawler.csproj
+++ b/Tharga.Crawler/Tharga.Crawler.csproj
@@ -1,26 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.0</Version>
 		<Authors>Daniel Bohlin</Authors>
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Crawler</Product>
 		<Description>Crawler framework.</Description>
 		<PackageIconUrl>https://thargelion.net/assets/component-crawler.png</PackageIconUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/Tharga/Crawler</PackageProjectUrl>
 		<DebugType>portable</DebugType>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 		<IncludeSource>true</IncludeSource>
 		<IncludeSymbols>true</IncludeSymbols>
+		<!-- Without this, pack emits the legacy .symbols.nupkg, which nuget.org
+		     rejects as a duplicate of the main package, so no symbols ship. -->
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	<PropertyGroup>
-		<NoWarn>1701;1702;CS1591;CS0809</NoWarn>
+		<!--
+			NU5048: PackageIconUrl is deprecated in favour of an embedded PackageIcon.
+			Suppressed deliberately. Tharga packages reference their icon from
+			https://thargelion.net/assets/ so all package icons are maintained in one
+			place and can be updated without republishing a package.
+		-->
+		<NoWarn>1701;1702;CS1591;CS0809;NU5048</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="README.md">


### PR DESCRIPTION
Tier 2 of the package cleanup sweep.

- **net10.0 only** — dropped net8.0 and net9.0 (both out of support 2026-11-10).
- **Tharga.Test.Toolkit 1.14.10 → 1.14.12**, and **Tharga.Console 4.1.2 → 4.2.0** in the sample console. The Console dependency edge comes from the *sample* project, which is why it does not show up in a top-level scan of the library.
- **Declared the licence.** The repo has an MIT LICENSE file but the package never said so — every push logged `License missing`.
- **Symbols now actually publish.** `SymbolPackageFormat` was unset, so pack emitted a legacy `.symbols.nupkg`; its filename still ends in `.nupkg`, so the push loop pushed it as a regular package and nuget.org rejected it as a duplicate of the main package. No symbols had ever shipped. Now `snupkg`.
- **Removed `<Version>1.0.0</Version>`** — it disagreed with the 1.1 series CI actually ships.
- CI: version computed before the build and passed as `-p:Version`; tag lookup guarded against a new `MAJOR_MINOR` series; SDK narrowed to 10.0.x.
- Solution items: removed `azure-pipelines.yml` and `buildnumber.yml`, which no longer exist.

Also keeps the original `$DOC_ROOT` mission.md change this branch started with.

44 tests passing, 1 skipped.