### PR TITLE
chore(deps): tier 2 cascade — Test.Toolkit 1.14.14, Console 4.2.1 + externals

### DIFF
--- a/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
+++ b/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="4.2.0" />
+		<PackageReference Include="Tharga.Console" Version="4.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -9,11 +9,11 @@
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
 		<PackageReference Include="FluentAssertions" Version="8.10.0" />
-		<PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.12" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.14" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tharga.Crawler/Tharga.Crawler.csproj
+++ b/Tharga.Crawler/Tharga.Crawler.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
 		<PackageReference Include="System.Linq.Async" Version="7.0.1" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
Second repo of **Tier 2** in the cascade update. Tier 1 is released and restorable, so this consumes it.

## Internal — consuming tier 1

- `Tharga.Test.Toolkit` 1.14.12 → **1.14.14** (test project)
- `Tharga.Console` 4.2.0 → **4.2.1** (`Sample/Tharga.Crawler.SampleConsole`)

Both verified **by an actual `dotnet restore`**, not just by the nuget.org flatcontainer listing — see the note at the bottom, which is worth reading before the next tier.

## External

**Library**
- `Microsoft.Extensions.Hosting` 10.0.9 → 10.0.11 (two patches behind — the largest external gap in this repo)

`HtmlAgilityPack` 1.12.4 and `System.Linq.Async` 7.0.1 are current and unchanged.

**Test tooling** (does not ship)
- `Microsoft.AspNetCore.Mvc.Testing` 10.0.9 → 10.0.11
- `Microsoft.NET.Test.Sdk` 18.6.0 → 18.9.0
- `JetBrains.Annotations` 2025.2.4 → 2026.2.0

## Verification

`dotnet build -c Release --no-incremental` — **0 warnings, 0 errors**. `dotnet test -c Release` — **44 passed, 1 skipped**, 0 failed. The single skip is pre-existing.

No source changes, no public API change, no `MAJOR_MINOR` bump.

## Note for the next tier: flatcontainer is not a restorable-ness check

This repo is where the cascade's verification step turned out to be wrong, so recording it here.

`Tharga.Test.Toolkit` 1.14.14 was confirmed "published" the usual way — the release run was green, the git tag existed, and
`https://api.nuget.org/v3-flatcontainer/tharga.test.toolkit/index.json` listed `1.14.14`. Restore still failed:

```
error NU1102: Unable to find package Tharga.Test.Toolkit with version (>= 1.14.14)
  - Found 123 version(s) in nuget.org [ Nearest version: 1.14.13 ]
```

nuget.org's package-content endpoint and the registration/search index that `dotnet restore` consults propagate **separately**, and the gap is minutes. So the flatcontainer probe is a fast pre-check, not a gate. Notably this was package-specific: `Tharga.Toolkit` 1.16.1, published in the same batch, restored immediately.

The cascade process doc has been corrected to gate on a real `dotnet restore` against a consuming solution instead.
