### PR TITLE
chore(deps): consume Tharga.Console 4.2.2 and Tharga.Test.Toolkit 1.14.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,11 +209,29 @@ jobs:
           if [ -n "${{ steps.version.outputs.previous_tag }}" ]; then
             NOTES_FLAG="--notes-start-tag ${{ steps.version.outputs.previous_tag }}"
           fi
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --generate-notes \
-            $NOTES_FLAG \
-            ./artifacts/*.nupkg
+          # The package is already on nuget.org by this point, so a transient GitHub API failure here
+          # leaves a published package with no tag. The next build then recomputes the SAME version,
+          # pushes a duplicate that --skip-duplicate swallows silently, and the version after it never
+          # ships. Observed three times on 2026-08-17 during a GitHub incident (HTTP 503/504).
+          # Retry, and treat an already-created release as success so a re-run is safe.
+          for attempt in 1 2 3 4 5; do
+            if gh release create "${{ steps.version.outputs.version }}" \
+                 --title "v${{ steps.version.outputs.version }}" \
+                 --generate-notes \
+                 $NOTES_FLAG \
+                 ./artifacts/*.nupkg; then
+              echo "Release ${{ steps.version.outputs.version }} created."
+              exit 0
+            fi
+            if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+              echo "Release ${{ steps.version.outputs.version }} already exists - an earlier attempt succeeded."
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Could not create the GitHub release for ${{ steps.version.outputs.version }} after 5 attempts. The package is most likely already on nuget.org, so the tag must be created by hand or the next release will silently republish this version: git tag ${{ steps.version.outputs.version }} <sha> && git push origin ${{ steps.version.outputs.version }}"
+          exit 1
 
       - name: Comment released version on merged PR
         if: always()
@@ -296,11 +314,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }} (pre-release)" \
-            --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
-            --prerelease \
-            ./artifacts/*.nupkg
+          # Same reasoning as the release job: the pre-release package is pushed before this runs, so a
+          # transient API failure would leave it published with no tag to match.
+          for attempt in 1 2 3 4 5; do
+            if gh release create "${{ steps.version.outputs.version }}" \
+                 --title "v${{ steps.version.outputs.version }} (pre-release)" \
+                 --notes "Pre-release from \`${{ github.head_ref }}\` branch." \
+                 --prerelease \
+                 ./artifacts/*.nupkg; then
+              echo "Pre-release ${{ steps.version.outputs.version }} created."
+              exit 0
+            fi
+            if gh release view "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+              echo "Pre-release ${{ steps.version.outputs.version }} already exists - an earlier attempt succeeded."
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in 20s..."
+            sleep 20
+          done
+          echo "::error::Could not create the GitHub pre-release for ${{ steps.version.outputs.version }} after 5 attempts."
+          exit 1
 
   docs:
     needs: release

--- a/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
+++ b/Sample/Tharga.Crawler.SampleConsole/Tharga.Crawler.SampleConsole.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Tharga.Console" Version="4.2.1" />
+		<PackageReference Include="Tharga.Console" Version="4.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
-		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.14" />
+		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.15" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
**Tier 2** of the cascade sweep, consuming the tier 1 releases.

## Internal

Verified restorable, not merely listed on nuget.org:

- `Tharga.Toolkit` 1.16.1 → **1.16.2** (Blazor)
- `Tharga.Console` 4.2.1 → **4.2.2** and `Tharga.Test.Toolkit` 1.14.14 → **1.14.15** (Crawler)

All patch-level. Nothing breaking reaches consumers through them, so **no `MAJOR_MINOR` bump**.

## External

Nothing outstanding. The only external work left in the ecosystem is the xunit 3 → 4 major, deferred by decision this sweep — see the parked PRs on Fortnox and Runtime for the recipe.

## Verification

`dotnet build -c Release --no-incremental` — 0 warnings, 0 errors. `dotnet test -c Release` green (Crawler's single skip is pre-existing).

## Also in this release

The `.claude/mission.md` cleanup already on master — `$DOC_ROOT` for the requests path, and the reference to a consuming product's checkout removed. It rides in this release rather than getting a version of its own.

## Note on release reliability

GitHub's release REST API has been returning `HTTP 503` intermittently today. It has already left three packages published with no tag (`Tharga.Mcp` 2.0.0, `Tharga.Console` 4.2.2, `Tharga.Toolkit` 1.16.2) because `dotnet nuget push` succeeds and the following `gh release create` then fails.

**That failure mode is worse than it looks:** with no tag, the next master build recomputes the same version, pushes a duplicate that `--skip-duplicate` swallows silently, and the version after it never ships. Each case was recovered by pushing a lightweight tag over the git protocol, which is unaffected by the API outage.

If this release lands without a tag, the fix is to **re-run the `release` job** — the push is idempotent — or to push the tag directly. Do not hand-build it with `git tag -a`; CI creates lightweight refs and an annotated tag is inconsistent with every other tag in the repo.
