### PR TITLE
chore(deps): xunit.v3 4.0.0 and the Microsoft.Testing.Platform runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
           fi
 
       - name: Test with coverage
-        run: dotnet test -c Release --no-build --verbosity normal --collect:"XPlat Code Coverage" --results-directory ./coverage
+        run: dotnet test -c Release --no-build --results-directory ./coverage -- --coverage --coverage-output-format cobertura
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -401,3 +401,6 @@ FodyWeavers.xsd
 # DocFX generated output
 /docs/_site/
 /docs/api/
+
+# Microsoft.Testing.Platform coverage output directory (--results-directory ./coverage)
+coverage/

--- a/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
+++ b/Tharga.Crawler.Tests/Tharga.Crawler.Tests.csproj
@@ -14,19 +14,12 @@
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
 		<PackageReference Include="Tharga.Test.Toolkit" Version="1.14.15" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.msbuild" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.v3" Version="3.2.2" />
+		<PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+		<PackageReference Include="xunit.v3" Version="4.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
xunit.v3 4.0.0 drops the VSTest bridge, so a version-only bump leaves the project unable to run tests at all:

    error : Testing with VSTest target is no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and later.

Completes the migration the same way it was already done in Cache, Fortnox, Mcp, Runtime and Wpf:

- xunit.v3 and xunit.runner.visualstudio to 4.0.0
- coverlet.collector / coverlet.msbuild replaced by Microsoft.Testing.Extensions.CodeCoverage 18.10.0
- global.json selecting the Microsoft.Testing.Platform runner
- the CI test command translated to Microsoft.Testing.Platform options, since the VSTest --filter expression, --verbosity and --collect:"XPlat Code Coverage" no longer apply
- coverage/ added to .gitignore

Verified locally: the solution builds clean and the full suite passes through the xunit.v3 in-process runner.